### PR TITLE
Fix/refactor transactions

### DIFF
--- a/app/Budget/TransactionExporter.php
+++ b/app/Budget/TransactionExporter.php
@@ -20,7 +20,7 @@ class TransactionExporter
     public function run(ExportCriteria $criteria = null): TransactionCollection
     {
         $criteria = $criteria ?? $this->criteria;
-        $this->budgetRepository->setToken($this->api_token);
+        $this->budgetRepository->setAccessToken($this->api_token);
         return $this->budgetRepository->findTransactionsSince($criteria->getStartDate());
     }
 

--- a/app/Budget/TransactionExporter.php
+++ b/app/Budget/TransactionExporter.php
@@ -3,7 +3,6 @@
 namespace App\Budget;
 
 use App\Exceptions\BudgetConnectionException;
-use App\Repositories\BudgetRepository;
 use App\Repositories\YnabBudgetRepository;
 
 class TransactionExporter
@@ -22,7 +21,7 @@ class TransactionExporter
     {
         $criteria = $criteria ?? $this->criteria;
         $this->budgetRepository->setToken($this->api_token);
-        return $this->budgetRepository->getTransactionsSince($criteria->getStartDate());
+        return $this->budgetRepository->findTransactionsSince($criteria->getStartDate());
     }
 
     public function setToken(string $token): void

--- a/app/Exceptions/BudgetAuthorizationException.php
+++ b/app/Exceptions/BudgetAuthorizationException.php
@@ -2,9 +2,7 @@
 
 namespace App\Exceptions;
 
-use Exception;
-
-class BudgetAuthorizationException extends Exception
+class BudgetAuthorizationException extends BudgetException
 {
     //
 }

--- a/app/Exceptions/BudgetAuthorizationException.php
+++ b/app/Exceptions/BudgetAuthorizationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class BudgetAuthorizationException extends Exception
+{
+    //
+}

--- a/app/Exceptions/BudgetConnectionException.php
+++ b/app/Exceptions/BudgetConnectionException.php
@@ -2,9 +2,7 @@
 
 namespace App\Exceptions;
 
-use Exception;
-
-class BudgetConnectionException extends Exception
+class BudgetConnectionException extends BudgetException
 {
     //
 }

--- a/app/Exceptions/BudgetException.php
+++ b/app/Exceptions/BudgetException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class BudgetException extends Exception
+{
+    //
+}

--- a/app/Exceptions/BudgetRateLimitException.php
+++ b/app/Exceptions/BudgetRateLimitException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class BudgetRateLimitException extends Exception
+{
+    //
+}

--- a/app/Exceptions/BudgetRateLimitException.php
+++ b/app/Exceptions/BudgetRateLimitException.php
@@ -2,9 +2,7 @@
 
 namespace App\Exceptions;
 
-use Exception;
-
-class BudgetRateLimitException extends Exception
+class BudgetRateLimitException extends BudgetException
 {
     //
 }

--- a/app/Exceptions/BudgetResourceNotFoundException.php
+++ b/app/Exceptions/BudgetResourceNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class BudgetResourceNotFoundException extends Exception
+{
+    //
+}

--- a/app/Exceptions/BudgetResourceNotFoundException.php
+++ b/app/Exceptions/BudgetResourceNotFoundException.php
@@ -2,9 +2,7 @@
 
 namespace App\Exceptions;
 
-use Exception;
-
-class BudgetResourceNotFoundException extends Exception
+class BudgetResourceNotFoundException extends BudgetException
 {
     //
 }

--- a/app/Factories/BaseFactory.php
+++ b/app/Factories/BaseFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Factories;
+
+abstract class BaseFactory
+{
+    protected int $count = 10;
+
+    public function make()
+    {
+        $payees = [];
+        for ($i = 0; $i < $this->count; $i++) {
+            $payees[] = $this->generateFactoryItem();
+        }
+        return $payees;
+    }
+
+    public function count($count): self
+    {
+        $this->count = $count;
+        return $this;
+    }
+
+    abstract protected function generateFactoryItem(): array;
+}

--- a/app/Factories/BudgetAccountFactory.php
+++ b/app/Factories/BudgetAccountFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Factories;
+
+class BudgetAccountFactory extends BaseFactory
+{
+    protected function generateFactoryItem(): array
+    {
+        $balance = fake()->randomNumber(8, true);
+
+        return [
+            'id' => fake()->uuid(),
+            'name' => fake()->word(2, true),
+            'type' => fake()->randomElement(['checking', 'savings']),
+
+            'on_budget' => fake()->boolean(),
+            'closed' => fake()->boolean(),
+            'note' => fake()->word(2, true),
+
+            'balance' => $balance,
+            'cleared_balance' => $balance,
+            'uncleared_balance' => $balance,
+
+            'transfer_payee_id' => fake()->uuid(),
+
+            'direct_import_linked' => fake()->boolean(),
+            'direct_import_in_error' => fake()->boolean(),
+
+            'last_reconciled_at' => fake()->date('Y-m-d H:i:s'),
+            'debt_original_balance' => $balance,
+            'debt_interest_rates' => [
+                'additionalProp1' => $balance,
+                'additionalProp2' => $balance,
+                'additionalProp3' => $balance,
+            ],
+            'debt_minimum_payments' => [
+                'additionalProp1' => $balance,
+                'additionalProp2' => $balance,
+                'additionalProp3' => $balance,
+            ],
+            'debt_escrow_amounts' => [
+                'additionalProp1' => $balance,
+                'additionalProp2' => $balance,
+                'additionalProp3' => $balance,
+            ],
+            'deleted' => fake()->boolean(),
+        ];
+    }
+}

--- a/app/Factories/BudgetCategoryFactory.php
+++ b/app/Factories/BudgetCategoryFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Factories;
+
+class BudgetCategoryFactory extends BaseFactory
+{
+    protected function generateFactoryItem(): array
+    {
+        return [
+            'id' => fake()->uuid(),
+            'name' => fake()->word(2, true),
+            'transfer_account_id' => fake()->word(2, true),
+            'deleted' => fake()->boolean(),
+        ];
+    }
+}

--- a/app/Factories/BudgetFactory.php
+++ b/app/Factories/BudgetFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Factories;
+
+class BudgetFactory extends BaseFactory
+{
+    protected function generateFactoryItem(array $accounts = []): array
+    {
+        return [
+            'id' => fake()->uuid(),
+            'name' => fake()->word(2, true),
+            'last_modified' => fake()->date('Y-m-d H:i:s', true),
+            'first_month' => fake()->date('Y-m-d'),
+            'last_month' => fake()->date('Y-m-d'),
+            'date_format' => [
+                'format' => ''
+            ],
+            'currency_format' => [
+                'iso_code' => '',
+                'example_format' => '',
+                'decimal_digits' => 1073741824,
+                'decimal_separator' => '.',
+                'symbol_first' => true,
+                'group_separator' => ',',
+                'currency_symbol' => '$',
+                'display_symbol' => true,
+            ],
+            'accounts' => $accounts,
+        ];
+    }
+}

--- a/app/Factories/BudgetPayeeFactory.php
+++ b/app/Factories/BudgetPayeeFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Factories;
+
+class BudgetPayeeFactory extends BaseFactory
+{
+    protected function generateFactoryItem(): array
+    {
+        return [
+            'id' => fake()->uuid(),
+            'name' => fake()->word(2, true),
+            'transfer_account_id' => fake()->word(2, true),
+            'deleted' => fake()->boolean(),
+        ];
+    }
+}

--- a/app/Factories/TransactionFactory.php
+++ b/app/Factories/TransactionFactory.php
@@ -5,7 +5,7 @@ namespace App\Factories;
 use App\Enums\TransactionClearedEnum;
 use App\Enums\TransactionFlagColorEnum;
 
-class TransactionCollectionFactory
+class TransactionFactory
 {
     protected int $count = 5;
     protected string $startDate = '-6 months';

--- a/app/Interfaces/BudgetRepositoryInterface.php
+++ b/app/Interfaces/BudgetRepositoryInterface.php
@@ -7,7 +7,11 @@ use App\DTOs\TransactionDTO;
 
 interface BudgetRepositoryInterface
 {
+    public function fetchAccounts(): array;
+    public function fetchBudgets(): array;
+    public function fetchCategories(): array;
+    public function fetchPayees(): array;
     public function getServiceName(): string;
-    public function getTransactionsSince(string $date): TransactionCollection;
-    public function getTransaction(string $id): TransactionDTO;
+    public function fetchTransactions(string $sinceDate): array;
+    public function fetchTransaction(string $id): array;
 }

--- a/app/Repositories/BudgetRepository.php
+++ b/app/Repositories/BudgetRepository.php
@@ -12,11 +12,9 @@ use Illuminate\Support\Facades\Http;
 
 abstract class BudgetRepository
 {
-    protected ExportCriteria $criteria; // remove this too.
-
     protected Response $response;
 
-    protected string $token = '';
+    protected string $accessToken = '';
 
     /**
      * @throws BudgetConnectionException
@@ -26,21 +24,28 @@ abstract class BudgetRepository
      */
     public function fetchJson(string $url, string $jsonKey): array
     {
-        $this->response = Http::withToken($this->getToken())->get($url);
+        $this->response = Http::withToken($this->getAccessToken())->get($url);
 
         if ($this->response->failed()) {
-            if ($this->response->status() === 401 || $this->response->status() === 403) {
-                throw new BudgetAuthorizationException();
+            $status = $this->response->status();
+            $reason = $this->response->reason();
+            if (401 === $status || 403 === $status) {
+                throw new BudgetAuthorizationException($reason, $status);
             }
-            if ($this->response->status() === 404) {
-                throw new BudgetResourceNotFoundException();
+            if (404 === $status) {
+                throw new BudgetResourceNotFoundException($reason, $status);
             }
-            if ($this->response->status() === 429) {
-                throw new BudgetRateLimitException();
+            if (429 === $status) {
+                throw new BudgetRateLimitException($reason, $status);
             }
             throw new BudgetConnectionException(
-                get_class($this) . ' unable to connect to ' . $this->getServiceName() . ' API',
-                $this->response->status()
+                sprintf(
+                    '%s unsable to connect to %s API: %s',
+                    get_class($this),
+                    $this->getServiceName(),
+                    $this->response->reason()
+                ),
+                $status
             );
         }
         return $this->response->json($jsonKey, []);
@@ -48,14 +53,14 @@ abstract class BudgetRepository
 
     abstract public function getServiceName(): string;
 
-    public function setToken(string $token): void
+    public function setAccessToken(string $token): void
     {
-        $this->token = $token;
+        $this->accessToken = $token;
     }
 
-    private function getToken(): string
+    private function getAccessToken(): string
     {
-        return $this->token;
+        return $this->accessToken;
     }
 
     public function getLastHttpResponse(): Response

--- a/app/Repositories/CachingBudgetRepository.php
+++ b/app/Repositories/CachingBudgetRepository.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Interfaces\BudgetRepositoryInterface;
+use Cache;
+
+class CachingBudgetRepository implements BudgetRepositoryInterface
+{
+    protected BudgetRepository $repository;
+    protected string $serviceName = 'Cache';
+
+    public function __construct(BudgetRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    private function makeCacheKey(string $id): string
+    {
+        return sprintf(
+            '%s.%s.%s',
+            strtolower($this->repository->getServiceName()),
+            $this->repository->getBudgetId(),
+            $id
+        );
+    }
+
+    public function fetchAccounts(): array
+    {
+        return Cache::remember($this->makeCacheKey('accounts'), $minutes = 10, function () {
+            return $this->repository->fetchAccounts();
+        });
+    }
+
+    public function fetchBudgets(bool $include_accounts = false): array
+    {
+        return Cache::remember($this->makeCacheKey('budgets'), $minutes = 10, function () {
+            return $this->repository->fetchBudgets();
+        });
+    }
+
+    public function fetchCategories(): array
+    {
+        return Cache::remember($this->makeCacheKey('categories'), $minutes = 10, function () {
+            return $this->repository->fetchBudgets();
+        });
+    }
+
+    public function fetchPayees(): array
+    {
+        return Cache::remember($this->makeCacheKey('payees'), $minutes = 10, function () {
+            return $this->repository->fetchPayees();
+        });
+    }
+
+    public function fetchTransactions(string $sinceDate): array
+    {
+        return Cache::remember($this->makeCacheKey('transactions'), $minutes = 10, function () {
+            return $this->repository->fetchPayees();
+        });
+    }
+
+    public function getBudgetId(): string
+    {
+        return $this->budgetId;
+    }
+
+    public function fetchTransaction(string $id): array
+    {
+        $url = sprintf(
+            $this->serviceUrl . '/budgets/%s/transactions/%s',
+            $this->budgetId,
+            $id
+        );
+        return $this->fetchJson($url, 'data.transaction');
+    }
+
+    public function getServiceName(): string
+    {
+        return $this->serviceName . ' <- ' . $this->repository->getServiceName();
+    }
+
+    public function setBudgetId(string $budgetId): void
+    {
+        $this->budgetId = $budgetId;
+    }
+}

--- a/app/Repositories/YnabBudgetRepository.php
+++ b/app/Repositories/YnabBudgetRepository.php
@@ -31,16 +31,6 @@ class YnabBudgetRepository extends BudgetRepository implements BudgetRepositoryI
         return $this->fetchJson($url, 'data.accounts');
     }
 
-    public function getBudgetId(): string
-    {
-        return $this->budgetId;
-    }
-
-    public function setBudgetId(string $budgetId): void
-    {
-        $this->budgetId = $budgetId;
-    }
-
     /**
      * @throws BudgetResourceNotFoundException
      * @throws BudgetAuthorizationException
@@ -89,9 +79,9 @@ class YnabBudgetRepository extends BudgetRepository implements BudgetRepositoryI
         return $this->fetchJson($url, 'data.payees');
     }
 
-    public function getServiceName(): string
+    public function getBudgetId(): string
     {
-        return $this->serviceName;
+        return $this->budgetId;
     }
 
     /**
@@ -119,10 +109,14 @@ class YnabBudgetRepository extends BudgetRepository implements BudgetRepositoryI
      * @throws BudgetRateLimitException
      * @throws BudgetConnectionException
      */
-    public function findTransactionsSince(string $sinceDate): TransactionCollection
+    public function fetchTransaction(string $id): array
     {
-        $transactions = $this->fetchTransactions($sinceDate);
-        return new TransactionCollection($transactions);
+        $url = sprintf(
+            $this->serviceUrl . '/budgets/%s/transactions/%s',
+            $this->budgetId,
+            $id
+        );
+        return $this->fetchJson($url, 'data.transaction');
     }
 
     /**
@@ -139,13 +133,19 @@ class YnabBudgetRepository extends BudgetRepository implements BudgetRepositoryI
      * @throws BudgetRateLimitException
      * @throws BudgetConnectionException
      */
-    public function fetchTransaction(string $id): array
+    public function findTransactionsSince(string $sinceDate): TransactionCollection
     {
-        $url = sprintf(
-            $this->serviceUrl . '/budgets/%s/transactions/%s',
-            $this->budgetId,
-            $id
-        );
-        return $this->fetchJson($url, 'data.transaction');
+        $transactions = $this->fetchTransactions($sinceDate);
+        return new TransactionCollection($transactions);
+    }
+
+    public function getServiceName(): string
+    {
+        return $this->serviceName;
+    }
+
+    public function setBudgetId(string $budgetId): void
+    {
+        $this->budgetId = $budgetId;
     }
 }

--- a/app/Repositories/YnabBudgetRepository.php
+++ b/app/Repositories/YnabBudgetRepository.php
@@ -13,19 +13,67 @@ class YnabBudgetRepository extends BudgetRepository implements BudgetRepositoryI
     protected string $serviceName = 'YNAB';
     protected string $serviceUrl = 'https://api.ynab.com/v1';
 
+    public function getAccounts(): array
+    {
+        $url = sprintf(
+            $this->serviceUrl . '/budgets/%s/accounts',
+            $this->budgetId
+        );
+        return $this->fetchJson($url, 'data.accounts');
+    }
+    public function getBudgetId(): string
+    {
+        return $this->budgetId;
+    }
+
+    public function setBudgetId(string $budgetId): void
+    {
+        $this->budgetId = $budgetId;
+    }
+
+    public function getBudgets(bool $include_accounts = false): array
+    {
+        $url = sprintf(
+            $this->serviceUrl . '/budgets',
+            $this->budgetId
+        );
+        $params = http_build_query([
+            'include_accounts' => $include_accounts,
+        ]);
+        return $this->fetchJson($url . '?' . $params, 'data.budgets');
+    }
+
+    public function getCategories(): array
+    {
+        $url = sprintf(
+            $this->serviceUrl . '/budgets/%s/categories',
+            $this->budgetId
+        );
+        return $this->fetchJson($url, 'data.categories');
+    }
+
     public function getServiceName(): string
     {
         return $this->serviceName;
     }
 
-    public function getTransactionsSince(string $date): TransactionCollection
+    public function getPayees(): array
+    {
+        $url = sprintf(
+            $this->serviceUrl . '/budgets/%s/payees',
+            $this->budgetId
+        );
+        return $this->fetchJson($url, 'data.payees');
+    }
+
+    public function getTransactions(string $since_date): TransactionCollection
     {
         $base_url = sprintf(
             $this->serviceUrl .  '/budgets/%s/transactions',
             $this->budgetId
         );
         $query_params = http_build_query([
-            'since_date' => $date,
+            'since_date' => $since_date,
         ]);
 
         $transactions = $this->fetchJson($base_url . '?' . $query_params, 'data.transactions');
@@ -44,15 +92,5 @@ class YnabBudgetRepository extends BudgetRepository implements BudgetRepositoryI
         );
         $data = $this->fetchJson($url, 'data.transaction');
         return TransactionDTO::fromArray($data);
-    }
-
-    public function getBudgetId(): string
-    {
-        return $this->budgetId;
-    }
-
-    public function setBudgetId(string $budgetId): void
-    {
-        $this->budgetId = $budgetId;
     }
 }

--- a/tests/Feature/ExportPreviewTest.php
+++ b/tests/Feature/ExportPreviewTest.php
@@ -2,19 +2,19 @@
 
 namespace Tests\Feature;
 
-use App\Factories\TransactionCollectionFactory;
+use App\Factories\TransactionFactory;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
 class ExportPreviewTest extends TestCase
 {
-    private TransactionCollectionFactory $transaction_factory;
+    private TransactionFactory $transaction_factory;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->transaction_factory = $this->app->make(TransactionCollectionFactory::class);
+        $this->transaction_factory = $this->app->make(TransactionFactory::class);
     }
 
     /**

--- a/tests/Feature/FetchTransactionsCommandTest.php
+++ b/tests/Feature/FetchTransactionsCommandTest.php
@@ -2,19 +2,19 @@
 
 namespace Tests\Feature;
 
-use App\Factories\TransactionCollectionFactory;
+use App\Factories\TransactionFactory;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class FetchTransactionsCommandTest extends TestCase
 {
 
-    private TransactionCollectionFactory $transaction_factory;
+    private TransactionFactory $transaction_factory;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->transaction_factory = $this->app->make(TransactionCollectionFactory::class);
+        $this->transaction_factory = $this->app->make(TransactionFactory::class);
     }
 
 

--- a/tests/Unit/FetchTransactionsTest.php
+++ b/tests/Unit/FetchTransactionsTest.php
@@ -6,7 +6,7 @@ use App\Budget\ExportCriteria;
 use App\Budget\TransactionCollection;
 use App\Budget\TransactionExporter;
 use App\Exceptions\BudgetConnectionException;
-use App\Factories\TransactionCollectionFactory;
+use App\Factories\TransactionFactory;
 use App\Repositories\YnabBudgetRepository;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Http;
@@ -16,12 +16,12 @@ class FetchTransactionsTest extends TestCase
 {
     use WithFaker;
 
-    private TransactionCollectionFactory $transaction_factory;
+    private TransactionFactory $transaction_factory;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->transaction_factory = $this->app->make(TransactionCollectionFactory::class);
+        $this->transaction_factory = $this->app->make(TransactionFactory::class);
     }
 
     /**

--- a/tests/Unit/TransactionCollectionTest.php
+++ b/tests/Unit/TransactionCollectionTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit;
 
 use App\Budget\TransactionCollection;
 use App\DTOs\TransactionDTO;
-use App\Factories\TransactionCollectionFactory;
+use App\Factories\TransactionFactory;
 use Tests\TestCase;
 
 class TransactionCollectionTest extends TestCase
@@ -14,7 +14,7 @@ class TransactionCollectionTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->transaction_factory = $this->app->make(TransactionCollectionFactory::class);
+        $this->transaction_factory = $this->app->make(TransactionFactory::class);
     }
 
     public function testCanCreateCollection(): void

--- a/tests/Unit/YnabBudgetRepositoryTest.php
+++ b/tests/Unit/YnabBudgetRepositoryTest.php
@@ -9,7 +9,6 @@ use App\Factories\BudgetAccountFactory;
 use App\Factories\BudgetCategoryFactory;
 use App\Factories\BudgetFactory;
 use App\Factories\BudgetPayeeFactory;
-use App\Factories\TransactionFactory;
 use App\Repositories\YnabBudgetRepository;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
@@ -32,9 +31,6 @@ class YnabBudgetRepositoryTest extends TestCase
         $this->payeeFactory    = $this->app->make(BudgetPayeeFactory::class);
     }
 
-    /**
-     * @throws BudgetConnectionException
-     */
     public function testCanFetchAccounts(): void
     {
         $budgetId = 'last-used';
@@ -53,9 +49,6 @@ class YnabBudgetRepositoryTest extends TestCase
         $this->assertCount($count, $response);
     }
 
-    /**
-     * @throws BudgetConnectionException
-     */
     public function testCanFetchBudgets(): void
     {
         $count = 3;
@@ -72,9 +65,6 @@ class YnabBudgetRepositoryTest extends TestCase
         $this->assertCount($count, $response);
     }
 
-    /**
-     * @throws BudgetConnectionException
-     */
     public function testCanFetchCategories(): void
     {
         $budgetId = 'last-used';

--- a/tests/Unit/YnabBudgetRepositoryTest.php
+++ b/tests/Unit/YnabBudgetRepositoryTest.php
@@ -16,11 +16,11 @@ use Tests\TestCase;
 
 class YnabBudgetRepositoryTest extends TestCase
 {
-    /**
-     * A basic unit test example.
-     */
+    private BudgetAccountFactory $accountFactory;
+    private BudgetFactory $budgetFactory;
+    private BudgetCategoryFactory $categoryFactory;
+    private BudgetPayeeFactory $payeeFactory;
 
-    private TransactionFactory $transactionFactory;
 
     public function setUp(): void
     {

--- a/tests/Unit/YnabBudgetRepositoryTest.php
+++ b/tests/Unit/YnabBudgetRepositoryTest.php
@@ -23,12 +23,11 @@ class YnabBudgetRepositoryTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+        Http::preventStrayRequests();
         $this->accountFactory  = $this->app->make(BudgetAccountFactory::class);
         $this->budgetFactory   = $this->app->make(BudgetFactory::class);
         $this->categoryFactory = $this->app->make(BudgetCategoryFactory::class);
         $this->payeeFactory    = $this->app->make(BudgetPayeeFactory::class);
-
-        Http::preventStrayRequests();
     }
 
     /**
@@ -46,7 +45,7 @@ class YnabBudgetRepositoryTest extends TestCase
         ]);
         $repository = new YnabBudgetRepository();
         $repository->setBudgetId($budgetId);
-        $response = $repository->getAccounts();
+        $response = $repository->fetchAccounts();
 
         $this->assertIsArray($response);
         $this->assertCount($count, $response);
@@ -65,7 +64,7 @@ class YnabBudgetRepositoryTest extends TestCase
             ))
         ]);
         $repository = new YnabBudgetRepository();
-        $response = $repository->getBudgets();
+        $response = $repository->fetchBudgets();
 
         $this->assertIsArray($response);
         $this->assertCount($count, $response);
@@ -86,7 +85,7 @@ class YnabBudgetRepositoryTest extends TestCase
         ]);
         $repository = new YnabBudgetRepository();
         $repository->setBudgetId($budgetId);
-        $response = $repository->getCategories();
+        $response = $repository->fetchCategories();
 
         $this->assertIsArray($response);
         $this->assertCount($count, $response);
@@ -107,7 +106,7 @@ class YnabBudgetRepositoryTest extends TestCase
         ]);
         $repository = new YnabBudgetRepository();
         $repository->setBudgetId($budgetId);
-        $response = $repository->getPayees();
+        $response = $repository->fetchPayees();
 
         $this->assertIsArray($response);
         $this->assertCount($count, $response);

--- a/tests/Unit/YnabBudgetRepositoryTest.php
+++ b/tests/Unit/YnabBudgetRepositoryTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Exceptions\BudgetConnectionException;
+use App\Factories\BudgetAccountFactory;
+use App\Factories\BudgetCategoryFactory;
+use App\Factories\BudgetFactory;
+use App\Factories\BudgetPayeeFactory;
+use App\Factories\TransactionFactory;
+use App\Repositories\YnabBudgetRepository;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class YnabBudgetRepositoryTest extends TestCase
+{
+    /**
+     * A basic unit test example.
+     */
+
+    private TransactionFactory $transactionFactory;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->accountFactory  = $this->app->make(BudgetAccountFactory::class);
+        $this->budgetFactory   = $this->app->make(BudgetFactory::class);
+        $this->categoryFactory = $this->app->make(BudgetCategoryFactory::class);
+        $this->payeeFactory    = $this->app->make(BudgetPayeeFactory::class);
+
+        Http::preventStrayRequests();
+    }
+
+    /**
+     * @throws BudgetConnectionException
+     */
+    public function testCanFetchAccounts(): void
+    {
+        $budgetId = 'last-used';
+        $count = 5;
+        Http::fake([
+            "https://api.ynab.com/v1/budgets/{$budgetId}/accounts" => Http::response($this->generateResponseArray(
+                'accounts',
+                $this->accountFactory->count($count)->make()
+            ))
+        ]);
+        $repository = new YnabBudgetRepository();
+        $repository->setBudgetId($budgetId);
+        $response = $repository->getAccounts();
+
+        $this->assertIsArray($response);
+        $this->assertCount($count, $response);
+    }
+
+    /**
+     * @throws BudgetConnectionException
+     */
+    public function testCanFetchBudgets(): void
+    {
+        $count = 3;
+        Http::fake([
+            "https://api.ynab.com/v1/budgets*" => Http::response($this->generateResponseArray(
+                'budgets',
+                $this->budgetFactory->count($count)->make()
+            ))
+        ]);
+        $repository = new YnabBudgetRepository();
+        $response = $repository->getBudgets();
+
+        $this->assertIsArray($response);
+        $this->assertCount($count, $response);
+    }
+
+    /**
+     * @throws BudgetConnectionException
+     */
+    public function testCanFetchCategories(): void
+    {
+        $budgetId = 'last-used';
+        $count = 10;
+        Http::fake([
+            "https://api.ynab.com/v1/budgets/{$budgetId}/categories" => Http::response($this->generateResponseArray(
+                'categories',
+                $this->categoryFactory->count($count)->make()
+            ))
+        ]);
+        $repository = new YnabBudgetRepository();
+        $repository->setBudgetId($budgetId);
+        $response = $repository->getCategories();
+
+        $this->assertIsArray($response);
+        $this->assertCount($count, $response);
+    }
+
+    /**
+     * @throws BudgetConnectionException
+     */
+    public function testCanFetchPayees(): void
+    {
+        $budgetId = 'last-used';
+        $count = 10;
+        Http::fake([
+            "https://api.ynab.com/v1/budgets/{$budgetId}/payees" => Http::response($this->generateResponseArray(
+                'payees',
+                $this->payeeFactory->count($count)->make()
+            ))
+        ]);
+        $repository = new YnabBudgetRepository();
+        $repository->setBudgetId($budgetId);
+        $response = $repository->getPayees();
+
+        $this->assertIsArray($response);
+        $this->assertCount($count, $response);
+    }
+
+    protected function generateResponseArray(string $key, array $data): array
+    {
+        return [
+            'data' => [
+                $key => $data,
+                'server_knowledge' => fake()->numberBetween(10000, 99999)
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Rearranged the project to use the Repository pattern to fetch each type from the YNAB API. 

While a typical Repository implementation might have a separate class for each entity — Transaction, Payee, Category, Budget, Account — our we are only reading from the YNAB API at this point and we don’t need the increased complexity of separate repo classes for simple read-only operations. The read-only nature of this project is why the Repository pattern was chosen over alternatives.

Added tests & factories for the new repository methods.

The CacheRepository is stated in this PR as well, which was an oversight but It's 1:30 and I'm the only developer on this project so I'm going to merge it anyway.
